### PR TITLE
fix: Pencil show up while already entered editing mode

### DIFF
--- a/files/client/modules/esignature/src/views/fields/esignature.js
+++ b/files/client/modules/esignature/src/views/fields/esignature.js
@@ -150,7 +150,7 @@ Espo.define('esignature:views/fields/esignature', ['views/fields/base', 'languag
             }.bind(this));
             $cell.on('mouseenter', function (e) {
                 e.stopPropagation();
-                if (this.disabled || this.readOnly) {
+                if (this.disabled || this.readOnly || this._isInlineEditMode) {
                         return;
                 }
                 if (this.mode === 'detail') {
@@ -164,7 +164,8 @@ Espo.define('esignature:views/fields/esignature', ['views/fields/base', 'languag
             }.bind(this));
         },
 
-        inlineEsignatureEdit: function() { // custom function equivalent to "inlineEdit" at base.js            
+        inlineEsignatureEdit: function() { // custom function equivalent to "inlineEdit" at base.js     
+            this._isInlineEditMode = true;       
             // add css class esignature to the field element
             this.$el.addClass('eSignature');
             // initialize jSignature plug-in to display canvas input


### PR DESCRIPTION
🛠️ Summary

This pull request fixes a UI logic issue where the pencil (edit) icon for the eSignature field was still visible and clickable even when the user was already in edit mode.
Previously, this caused multiple signature pads to open at the same time or unexpected behavior during editing.

✅ Changes

Added a condition to check whether the field is already in edit mode before showing the pencil icon.

Prevented the icon from being re-shown while the user is actively signing.

🎯 Result

The pencil icon is now hidden during editing, avoiding redundant UI actions.

Prevents users from unintentionally opening multiple signature fields.

Provides a cleaner, more predictable user experience when capturing electronic signatures.

🧩 Additional Notes

No changes were made to data handling or signature rendering logic.
This fix only affects frontend interaction in the detail view for signature fields.